### PR TITLE
prometheus serviceMonitor config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ resource "helm_release" "trivy-system" {
   namespace  = kubernetes_namespace.trivy-system.id
   repository = "https://aquasecurity.github.io/helm-charts/"
   chart      = "trivy-operator"
-  version    = "0.10.1"
+  version    = "0.10.2"
 
   values = [
     templatefile("${path.module}/templates/values.yaml.tpl",
@@ -58,6 +58,16 @@ resource "helm_release" "trivy-system" {
         github-access-token = var.github_token
     })
   ]
+
+  set {
+    name  = "prometheus.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "serviceMonitor.enabled"
+    value = "true"
+  }
 
   lifecycle {
     ignore_changes = [keyring]

--- a/main.tf
+++ b/main.tf
@@ -59,10 +59,6 @@ resource "helm_release" "trivy-system" {
     })
   ]
 
-  set {
-    name  = "prometheus.enabled"
-    value = "true"
-  }
 
   set {
     name  = "serviceMonitor.enabled"


### PR DESCRIPTION
Why: [Phase 5: Trivy Scan#4332](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4332)
Add serviceMonitor config for Prometheus-operator end point 