### PR TITLE
increase scanJobTimeout to 10m

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -16,8 +16,17 @@ trivy:
   githubToken: "${github-access-token}"
 
 operator:
-  # Dockerhub credentials obtained via namespace secret
+
+  # scanJobTTL the set automatic cleanup time after the job is completed
+  # scanJobTTL:
+
+  # scanJobTimeout the length of time to wait before giving up on a scan job
+  scanJobTimeout: 10m
+
+  # scanJobsConcurrentLimit the maximum number of scan jobs create by the operator
   scanJobsConcurrentLimit: ${job_concurrency_limit} 
+
+  # Dockerhub credentials obtained via namespace secret
   privateRegistryScanSecretsNames: {"trivy-system":"dockerhub-credentials"}
 
 serviceAccount:


### PR DESCRIPTION
Doubling the scan job timeout value to allow larger image scans time to complete without a `deadline exceeded`