### PR TITLE
Service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ See the [examples/](examples/) folder for more information.
 | <a name="input_dockerhub_password"></a> [dockerhub\_password](#input\_dockerhub\_password) | DockerHub password - required to avoid hitting Dockerhub API limits in EKS clusters | `string` | `""` | no |
 | <a name="input_dockerhub_username"></a> [dockerhub\_username](#input\_dockerhub\_username) | DockerHub username - required to avoid hitting Dockerhub API limits in EKS clusters | `string` | `""` | no |
 | <a name="input_eks_cluster_oidc_issuer_url"></a> [eks\_cluster\_oidc\_issuer\_url](#input\_eks\_cluster\_oidc\_issuer\_url) | This is going to be used when we create the IAM OIDC role | `string` | `""` | no |
+| <a name="input_enable_config_audit"></a> [enable\_config\_audit](#input\_enable\_config\_audit) | flag to enable configuration audit scanner | `string` | `"false"` | no |
+| <a name="input_enable_infra_assess"></a> [enable\_infra\_assess](#input\_enable\_infra\_assess) | flag to enable infra assessment scanner | `string` | `"false"` | no |
+| <a name="input_enable_rbac_assess"></a> [enable\_rbac\_assess](#input\_enable\_rbac\_assess) | flag to enable rbac assessment scanner | `string` | `"false"` | no |
+| <a name="input_enable_secret_scan"></a> [enable\_secret\_scan](#input\_enable\_secret\_scan) | flag to enable exposed secret scanner | `string` | `"false"` | no |
 | <a name="input_enable_trivy_server"></a> [enable\_trivy\_server](#input\_enable\_trivy\_server) | Enable built-in trivy server (clientServer mode). If true, do not set githubToken value | `string` | `"false"` | no |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | GitHub Personal Access Token | `string` | `""` | no |
 | <a name="input_job_concurrency_limit"></a> [job\_concurrency\_limit](#input\_job\_concurrency\_limit) | Sets the maximum value for concurrent report jobs | `number` | `10` | no |

--- a/README.md
+++ b/README.md
@@ -61,15 +61,18 @@ See the [examples/](examples/) folder for more information.
 | <a name="input_eks_cluster_oidc_issuer_url"></a> [eks\_cluster\_oidc\_issuer\_url](#input\_eks\_cluster\_oidc\_issuer\_url) | This is going to be used when we create the IAM OIDC role | `string` | `""` | no |
 | <a name="input_enable_trivy_server"></a> [enable\_trivy\_server](#input\_enable\_trivy\_server) | Enable built-in trivy server (clientServer mode). If true, do not set githubToken value | `string` | `"false"` | no |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | GitHub Personal Access Token | `string` | `""` | no |
-| <a name="input_job_concurrency_limit"></a> [job\_concurrency\_limit](#input\_job\_concurrency\_limit) | Sets the maximum value for concurrent report jobs | `number` | `5` | no |
+| <a name="input_job_concurrency_limit"></a> [job\_concurrency\_limit](#input\_job\_concurrency\_limit) | Sets the maximum value for concurrent report jobs | `number` | `10` | no |
 | <a name="input_memory_limit"></a> [memory\_limit](#input\_memory\_limit) | resources:limit memory value | `string` | `"500M"` | no |
 | <a name="input_memory_limit_non_live"></a> [memory\_limit\_non\_live](#input\_memory\_limit\_non\_live) | Non-live cluster value for resources:limit memory value | `string` | `"500M"` | no |
 | <a name="input_memory_requests"></a> [memory\_requests](#input\_memory\_requests) | resources:requests memory value | `string` | `"100M"` | no |
 | <a name="input_memory_requests_non_live"></a> [memory\_requests\_non\_live](#input\_memory\_requests\_non\_live) | Non-live clustrer value for resources:requests memory value | `string` | `"100M"` | no |
 | <a name="input_role_key_annotation"></a> [role\_key\_annotation](#input\_role\_key\_annotation) | The annotation key to use for the role key | `string` | `"eks.amazonaws.com/role-arn"` | no |
 | <a name="input_scan_job_timeout"></a> [scan\_job\_timeout](#input\_scan\_job\_timeout) | The length of time to wait before giving up on a scan job | `string` | `"5m"` | no |
+| <a name="input_scanner_report_ttl"></a> [scanner\_report\_ttl](#input\_scanner\_report\_ttl) | flag to set how long a report should exist. When a old report is deleted a new one will be created by the controller. | `string` | `"24h"` | no |
 | <a name="input_service_monitor_enabled"></a> [service\_monitor\_enabled](#input\_service\_monitor\_enabled) | Enable ServiceMonitor for Prometheus Operator | `bool` | `true` | no |
 | <a name="input_severity_list"></a> [severity\_list](#input\_severity\_list) | A single string providing comma separated list of CVE Severity levels to be monitored. Possible values are UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL | `string` | `"UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"` | no |
+| <a name="input_trivy_service_account"></a> [trivy\_service\_account](#input\_trivy\_service\_account) | Name of the k8s Service Account. If not set, name is generated automatically. | `string` | `""` | no |
+| <a name="input_trivy_timeout"></a> [trivy\_timeout](#input\_trivy\_timeout) | Duration to wait for scan completion | `string` | `"5m0s"` | no |
 
 ## Outputs
 

--- a/examples/trivy.tf
+++ b/examples/trivy.tf
@@ -6,11 +6,13 @@
  */
 
 module "trivy-operator" {
-  source = "github.com/ministryofjustice/cloud-platfrom-terraform-trivy-operator?ref=0.1"
+  source = "github.com/ministryofjustice/cloud-platfrom-terraform-trivy-operator?ref=0.2.5"
 
-  dockerhub_username = var.dockerhub_username
-  dockerhub_password = var.dockerhub_password
-
+  dockerhub_username      = var.dockerhub_username
+  dockerhub_password      = var.dockerhub_password
+  job_concurrency_limit   = 5
+  scan_job_timeout        = "10m"
+  trivy_timeout           = "10m0s"
   severity_list           = "HIGH,CRITICAL"
   service_monitor_enabled = true
 }

--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,7 @@ resource "helm_release" "trivy-system" {
     enable_trivy_server     = var.enable_trivy_server
     trivy_service_account   = var.trivy_service_account
     trivy_timeout           = var.trivy_timeout
+    scanner_report_ttl      = var.scanner_report_ttl
     })
   ]
 

--- a/main.tf
+++ b/main.tf
@@ -43,6 +43,10 @@ resource "helm_release" "trivy-system" {
     trivy_service_account   = var.trivy_service_account
     trivy_timeout           = var.trivy_timeout
     scanner_report_ttl      = var.scanner_report_ttl
+    enable_config_audit     = var.enable_config_audit
+    enable_rbac_assess      = var.enable_rbac_assess
+    enable_infra_assess     = var.enable_infra_assess
+    enable_secret_scan      = var.enable_secret_scan
     })
   ]
 

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,7 @@ resource "helm_release" "trivy-system" {
     scan_job_timeout        = var.scan_job_timeout
     enable_trivy_server     = var.enable_trivy_server
     trivy_service_account   = var.trivy_service_account
+    trivy_timeout           = var.trivy_timeout
     })
   ]
 

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,7 @@ resource "helm_release" "trivy-system" {
     job_concurrency_limit   = var.job_concurrency_limit
     scan_job_timeout        = var.scan_job_timeout
     enable_trivy_server     = var.enable_trivy_server
+    trivy_service_account   = var.trivy_service_account
     })
   ]
 

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -4,7 +4,7 @@ trivy:
   severity: "${severity_level}"
 
   # timeout is the duration to wait for scan completion.
-  timeout: "{$trivy_timeout}"
+  timeout: "${trivy_timeout}"
   
   resources:
     requests:

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -40,7 +40,7 @@ serviceAccount:
     "${role_key_annotation}": "${eks_service_account}"
   # name specifies the name of the k8s Service Account. If not set and create is
   # true, a name is generated using the fullname template.
-  name: ""
+  name: "${trivy_service_account}"
 
 # Prometheus ServiceMonitor configuration -- to install the trivy operator with the ServiceMonitor
 # you must have Prometheus already installed and running

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -26,6 +26,9 @@ operator:
   # scanJobTimeout the length of time to wait before giving up on a scan job
   scanJobTimeout: ${scan_job_timeout}
 
+  # scannerReportTTL the flag to set how long a report should exist. "" means that the ScannerReportTTL feature is disabled
+  scannerReportTTL: "${scanner_report_ttl}"
+
   # scanJobsConcurrentLimit the maximum number of scan jobs create by the operator
   scanJobsConcurrentLimit: ${job_concurrency_limit} 
 

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -29,6 +29,15 @@ operator:
   # scannerReportTTL the flag to set how long a report should exist. "" means that the ScannerReportTTL feature is disabled
   scannerReportTTL: "${scanner_report_ttl}"
 
+  # configAuditScannerEnabled the flag to enable configuration audit scanner
+  configAuditScannerEnabled: ${enable_config_audit}
+
+  # rbacAssessmentScannerEnabled the flag to enable rbac assessment scanner
+  rbacAssessmentScannerEnabled: ${enable_rbac_assess}
+
+  # infraAssessmentScannerEnabled the flag to enable infra assessment scanner
+  infraAssessmentScannerEnabled: ${enable_infra_assess}
+
   # scanJobsConcurrentLimit the maximum number of scan jobs create by the operator
   scanJobsConcurrentLimit: ${job_concurrency_limit} 
 
@@ -36,6 +45,9 @@ operator:
   # trivy.mode = ClientServer and serverURL = http://<serverServiceName>.<trivy operator namespace>:4975 
   builtInTrivyServer: ${enable_trivy_server}
 
+  # exposedSecretScannerEnabled the flag to enable exposed secret scanner
+  exposedSecretScannerEnabled: ${enable_secret_scan}
+  
   # Dockerhub credentials obtained via namespace secret
   privateRegistryScanSecretsNames: {"trivy-system":"dockerhub-credentials"}
 

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -2,6 +2,9 @@ trivy:
   
   # severity is a comma separated string list of CVE severity levels to monitor. Possible values are UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL
   severity: "${severity_level}"
+
+  # timeout is the duration to wait for scan completion.
+  timeout: "{$trivy_timeout}"
   
   resources:
     requests:

--- a/variables.tf
+++ b/variables.tf
@@ -121,3 +121,9 @@ variable "trivy_timeout" {
   default     = "5m0s"
   type        = string
 }
+
+variable "scanner_report_ttl" {
+  description = "flag to set how long a report should exist. When a old report is deleted a new one will be created by the controller."
+  default     = "24h"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -109,3 +109,9 @@ variable "enable_trivy_server" {
   default     = "false"
   type        = string
 }
+
+variable "trivy_service_account" {
+  description = "Name of the k8s Service Account. If not set, name is generated automatically."
+  default     = ""
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -127,3 +127,27 @@ variable "scanner_report_ttl" {
   default     = "24h"
   type        = string
 }
+
+variable "enable_config_audit" {
+  description = "flag to enable configuration audit scanner"
+  default     = "false"
+  type        = string
+}
+
+variable "enable_rbac_assess" {
+  description = "flag to enable rbac assessment scanner"
+  default     = "false"
+  type        = string
+}
+
+variable "enable_infra_assess" {
+  description = "flag to enable infra assessment scanner"
+  default     = "false"
+  type        = string
+}
+
+variable "enable_secret_scan" {
+  description = "flag to enable exposed secret scanner"
+  default     = "false"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -94,7 +94,7 @@ variable "cpu_requests_non_live" {
 
 variable "job_concurrency_limit" {
   description = "Sets the maximum value for concurrent report jobs"
-  default     = 5
+  default     = 10
   type        = number
 }
 
@@ -113,5 +113,11 @@ variable "enable_trivy_server" {
 variable "trivy_service_account" {
   description = "Name of the k8s Service Account. If not set, name is generated automatically."
   default     = ""
+  type        = string
+}
+
+variable "trivy_timeout" {
+  description = "Duration to wait for scan completion"
+  default     = "5m0s"
   type        = string
 }


### PR DESCRIPTION
This PR facilitates the passing additional Helm Chart values via Terraform variables during module call, in order to allow more flexible configuration of the `trivy-operator`.

```
- scanJobTimeout
- trivy.timeout
- serviceAccount
- scannerReportTTL
- builtInTrivyServer
```
and toggle additional resource scanners to disabled (we're just interested in scanning images for now)
```
- configAuditScannerEnabled
- rbacAssessmentScannerEnabled
- infraAssessmentScannerEnabled
- exposedSecretScannerEnabled
```