### PR TITLE
update trivy-operator chart version to 0.12.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "helm_release" "trivy-system" {
   namespace  = kubernetes_namespace.trivy-system.id
   repository = "https://aquasecurity.github.io/helm-charts/"
   chart      = "trivy-operator"
-  version    = "0.10.2"
+  version    = "0.12.1"
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     severity_level          = var.severity_list,


### PR DESCRIPTION
This PR updates the trivy-operator Helm Chart to latest release, containing a [fix ](https://github.com/aquasecurity/trivy-operator/pull/977/files#diff-469d360fcbb4165cd38b47c205d92fe32006f484f92e124461a5d5bf1842c2bcR58)that allows us to utlilise a client-server architecture: