### PR TITLE
update trivy chart to 0.13

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "helm_release" "trivy-system" {
   namespace  = kubernetes_namespace.trivy-system.id
   repository = "https://aquasecurity.github.io/helm-charts/"
   chart      = "trivy-operator"
-  version    = "0.12.1"
+  version    = "0.13.0"
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     severity_level          = var.severity_list,


### PR DESCRIPTION
bump operator chart release to 0.13 to resolve issue with cluster compliance reporting:
https://github.com/aquasecurity/trivy-operator/issues/1078