### PR TITLE
Exclude kuberhealthy

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -1,3 +1,6 @@
+# -- excludeNamespaces is a comma separated list of namespaces (or glob patterns)
+# to be excluded from scanning. Only applicable in the all namespaces install
+# mode, i.e. when the targetNamespaces values is a blank string.
 excludeNamespaces: "kuberhealthy"
 
 trivy:

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -1,3 +1,5 @@
+excludeNamespaces: "kuberhealthy"
+
 trivy:
   
   # severity is a comma separated string list of CVE severity levels to monitor. Possible values are UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL


### PR DESCRIPTION
We know from the dockerhub pull rate issue that kuberhealthy images keep trivy scanners very busy (`kuberhealthy-namespace-check` 17,000 + daily hits).  We're now scanning images locally, but this PR is to skip vulnerability scanning for `kuberhealthy` namespace and free up some scanning resource for the rest of the cluster.