### PR TITLE
Bump helm version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "helm_release" "trivy-system" {
   namespace  = kubernetes_namespace.trivy-system.id
   repository = "https://aquasecurity.github.io/helm-charts/"
   chart      = "trivy-operator"
-  version    = "0.13.0"
+  version    = "0.18.4"
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     severity_level          = var.severity_list,

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -5,6 +5,15 @@ excludeNamespaces: "kuberhealthy"
 
 trivy:
   
+  # As a temporary fix to alleviate trivy images own CVEs flagging in cluster-wide image vuln reports, we are 
+  # bumping trivy binary image beyond chart 0.18.4 default tag. 
+   image:
+    # -- registry of the Trivy image
+    registry: ghcr.io
+    # -- repository of the Trivy image
+    repository: aquasecurity/trivy
+    # -- tag version of the Trivy image
+    tag: 0.47.0 
   # severity is a comma separated string list of CVE severity levels to monitor. Possible values are UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL
   severity: "${severity_level}"
 

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -7,8 +7,8 @@ trivy:
   
   # As a temporary fix to alleviate trivy images own CVEs flagging in cluster-wide image vuln reports, we are 
   # bumping trivy binary image beyond chart 0.18.4 default tag. 
-   image:
-    # -- registry of the Trivy image
+  image:
+  # -- registry of the Trivy image
     registry: ghcr.io
     # -- repository of the Trivy image
     repository: aquasecurity/trivy

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -51,6 +51,9 @@ operator:
   # clusterComplianceEnabled the flag to enable cluster compliance report generation 
   clusterComplianceEnabled: false
 
+  # -- the flag to enable sbom generation
+  sbomGenerationEnabled: false 
+
   # scanJobsConcurrentLimit the maximum number of scan jobs create by the operator
   scanJobsConcurrentLimit: ${job_concurrency_limit} 
 


### PR DESCRIPTION
trivy-operator and scanner binary image upgrade. Relates to:
https://github.com/ministryofjustice/cloud-platform/issues/4966
