### PR TITLE
chore: 🤖 bump helm version and exclude smoketest ns

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "helm_release" "trivy-system" {
   namespace  = kubernetes_namespace.trivy-system.id
   repository = "https://aquasecurity.github.io/helm-charts/"
   chart      = "trivy-operator"
-  version    = "0.18.4"
+  version    = "0.25.0"
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     severity_level          = var.severity_list,

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -1,19 +1,10 @@
 # -- excludeNamespaces is a comma separated list of namespaces (or glob patterns)
 # to be excluded from scanning. Only applicable in the all namespaces install
 # mode, i.e. when the targetNamespaces values is a blank string.
-excludeNamespaces: "kuberhealthy"
+excludeNamespaces: "kuberhealthy, *smoketest*"
 
 trivy:
   
-  # As a temporary fix to alleviate trivy images own CVEs flagging in cluster-wide image vuln reports, we are 
-  # bumping trivy binary image beyond chart 0.18.4 default tag. 
-  image:
-  # -- registry of the Trivy image
-    registry: ghcr.io
-    # -- repository of the Trivy image
-    repository: aquasecurity/trivy
-    # -- tag version of the Trivy image
-    tag: 0.47.0 
   # severity is a comma separated string list of CVE severity levels to monitor. Possible values are UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL
   severity: "${severity_level}"
 


### PR DESCRIPTION
- Updating to latest helm release 
- removing image version override from values
- setting trivy operator to ignore `smoketest` namespaces