### PR TITLE
chore: 🤖 add system namespaces to exclusion list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,8 +46,8 @@ resource "helm_release" "trivy-system" {
     enable_config_audit     = var.enable_config_audit
     enable_rbac_assess      = var.enable_rbac_assess
     enable_infra_assess     = var.enable_infra_assess
-    enable_secret_scan      = var.enable_secret_scan,
-    exclude_namespaces      = var.exclude_namespaces,
+    enable_secret_scan      = var.enable_secret_scan
+    exclude_namespaces      = var.exclude_namespaces
     })
   ]
 

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,8 @@ resource "helm_release" "trivy-system" {
     enable_config_audit     = var.enable_config_audit
     enable_rbac_assess      = var.enable_rbac_assess
     enable_infra_assess     = var.enable_infra_assess
-    enable_secret_scan      = var.enable_secret_scan
+    enable_secret_scan      = var.enable_secret_scan,
+    exclude_namespaces      = var.exclude_namespaces,
     })
   ]
 

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -1,7 +1,7 @@
 # -- excludeNamespaces is a comma separated list of namespaces (or glob patterns)
 # to be excluded from scanning. Only applicable in the all namespaces install
 # mode, i.e. when the targetNamespaces values is a blank string.
-excludeNamespaces: "kuberhealthy, *smoketest*"
+excludeNamespaces: "${exclude_namespaces}"
 
 trivy:
   

--- a/variables.tf
+++ b/variables.tf
@@ -151,3 +151,9 @@ variable "enable_secret_scan" {
   default     = "false"
   type        = string
 }
+
+variable "exclude_namespaces" {
+  description = "Comma separated string of namespaces to exclude from scanning"
+  default     = "kube-system, cert-manager, calico-system, calico-api-server, kuberhealthy, gatekeeper-system, ingress-controllers, tigera-operator, logging, monitoring, velero, trivy-system, external-secrets-operator, *smoketest*"
+  type        = string
+}


### PR DESCRIPTION
Rationale: we don't manage the underlying images for these namespaces