### PR TITLE
chore: bump memory limit for live cluster

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,7 @@ variable "role_key_annotation" {
 
 variable "memory_limit" {
   description = "resources:limit memory value"
-  default     = "1000M"
+  default     = "3000M"
   type        = string
 }
 


### PR DESCRIPTION
This PR increases the memory limit for the Trivy Operator in the `live` cluster.

There were also some Trivy job pods are exceeding the current memory limit, leading to OOM terminations. These failures have caused job disruptions and incomplete scans.




![image](https://github.com/user-attachments/assets/1a3f19a3-9a4c-49bc-a615-4efa2b713490)
