### PR TITLE
Set requests

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -10,11 +10,6 @@ resources:
 # mode, i.e. when the targetNamespaces values is a blank string.
 excludeNamespaces: "*smoketest*"
 
-# -- excludeNamespaces is a comma separated list of namespaces (or glob patterns)
-# to be excluded from scanning. Only applicable in the all namespaces install
-# mode, i.e. when the targetNamespaces values is a blank string.
-excludeNamespaces: "kuberhealthy, *smoketest*"
-
 trivy:
   
   # severity is a comma separated string list of CVE severity levels to monitor. Possible values are UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -3,7 +3,7 @@
 
 resources:
   requests:
-  memory: 1500Mi
+    memory: 1500Mi
 
 # -- excludeNamespaces is a comma separated list of namespaces (or glob patterns)
 # to be excluded from scanning. Only applicable in the all namespaces install

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -1,3 +1,15 @@
+# trivy-operator requests is defined at top level
+# we are ensuring operator is scheduled with suitable memory for live cluster
+
+resources:
+  requests:
+  memory: 1500Mi
+
+# -- excludeNamespaces is a comma separated list of namespaces (or glob patterns)
+# to be excluded from scanning. Only applicable in the all namespaces install
+# mode, i.e. when the targetNamespaces values is a blank string.
+excludeNamespaces: "*smoketest*"
+
 # -- excludeNamespaces is a comma separated list of namespaces (or glob patterns)
 # to be excluded from scanning. Only applicable in the all namespaces install
 # mode, i.e. when the targetNamespaces values is a blank string.


### PR DESCRIPTION
- trivy-operator runs with mem usage around 1 > 1.5G. Ensure scheduling is suitable.
- remove redundant kuberhealthy namespace exclusion